### PR TITLE
fix array index to make scroll lock LED work

### DIFF
--- a/Source/SetLEDs/main.c
+++ b/Source/SetLEDs/main.c
@@ -101,7 +101,7 @@ void setKeyboard(struct __IOHIDDevice *device, CFDictionaryRef keyboardDictionar
             if (element && kHIDPage_LEDs == IOHIDElementGetUsagePage(element)) {
                 uint32_t led = IOHIDElementGetUsage(element);
 
-                if (led >= maxLeds) break;
+                if (led > maxLeds) break;
                 
                 // Get current keyboard led status
                 IOHIDValueRef currentValue = 0;


### PR DESCRIPTION
Reproduced [Scroll Lock LED doesn't work issue](https://github.com/damieng/setledsmac/issues/4) on my Leopold FC750R and my Das Professional Model S.

With this fix, scroll lock LED can be controlled on both boards.  All three LEDs work on the Das.  Leopold doesn't have num lock LED, but caps and scroll lock LEDs both work.