### PR TITLE
[build] mildly improve the makefile

### DIFF
--- a/Source/SetLEDs/Makefile
+++ b/Source/SetLEDs/Makefile
@@ -1,5 +1,5 @@
-setleds :
-	gcc -o setleds main.c -framework Foundation -framework IOKit
+setleds: main.c main.h
+	$(CC) -o $@ $< -framework Foundation -framework IOKit
 
 clean :
 	rm -f setleds


### PR DESCRIPTION
This avoids depending on specific compilers, or repeating the name of
executible/source code.  Further it results in running `make` multiple
times not rebuild the executable unless the binary has changed.