### PR TITLE
Support legacy compose and kana keyboard LEDs too

### DIFF
--- a/Source/SetLEDs/main.c
+++ b/Source/SetLEDs/main.c
@@ -27,7 +27,7 @@ void parseOptions(int argc, const char * argv[])
         exit(1);
     }
     
-    LedState changes[] = { NoChange, NoChange, NoChange, NoChange };
+    LedState changes[] = { NoChange, NoChange, NoChange, NoChange, NoChange, NoChange };
     
     bool nextIsName = false;
     
@@ -61,6 +61,22 @@ void parseOptions(int argc, const char * argv[])
         else if (strcasecmp(argv[i], "^scroll") == 0)
             changes[kHIDUsage_LED_ScrollLock] = Toggle;
 
+        // Scroll lock
+        else if (strcasecmp(argv[i], "+compose") == 0)
+            changes[kHIDUsage_LED_Compose] = On;
+        else if (strcasecmp(argv[i], "-compose") == 0)
+            changes[kHIDUsage_LED_Compose] = Off;
+        else if (strcasecmp(argv[i], "^compose") == 0)
+            changes[kHIDUsage_LED_Compose] = Toggle;
+
+        // Kana
+        else if (strcasecmp(argv[i], "+kana") == 0)
+            changes[kHIDUsage_LED_Kana] = On;
+        else if (strcasecmp(argv[i], "-kana") == 0)
+            changes[kHIDUsage_LED_Kana] = Off;
+        else if (strcasecmp(argv[i], "^kana") == 0)
+            changes[kHIDUsage_LED_Kana] = Toggle;
+
         else {
             if (nextIsName) {
                 nameMatch = argv[i];
@@ -79,7 +95,7 @@ void parseOptions(int argc, const char * argv[])
 
 void explainUsage(void)
 {
-    printf("Usage:\tsetleds [-v] [-name wildcard] [[+|-|^][ num | caps | scroll]]\n"
+    printf("Usage:\tsetleds [-v] [-name wildcard] [[+|-|^][ num | caps | scroll | compose | kana ]]\n"
            "Thus,\tsetleds +caps -num ^scroll\n"
            "will set CapsLock, clear NumLock and toggle ScrollLock.\n"
            "Any leds changed are reported for each keyboard.\n"

--- a/Source/SetLEDs/main.h
+++ b/Source/SetLEDs/main.h
@@ -8,8 +8,8 @@
 
 #include <CoreFoundation/CoreFoundation.h>
 
-const int maxLeds = 3;
-const char* ledNames[] = { "num", "caps", "scroll" };
+const int maxLeds = 5;
+const char* ledNames[] = { "num", "caps", "scroll", "compose", "kana" };
 const char* stateSymbol[] = {"-", "+" };
 typedef enum { NoChange = -1, Off, On, Toggle } LedState;
 


### PR DESCRIPTION
I do not have a Japanese keyboard with the kana LED to test this directly. This seems to work based on testing with a DIY keyboard using QMK to report the LED state via the colour of an RGB LED.

My motivation is as per https://github.com/pqrs-org/Karabiner-Elements/issues/3173#issuecomment-3099740236 (meaning using `setledmac` is a proof of principle only for me).